### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/SpeedTrig/keywords.txt
+++ b/SpeedTrig/keywords.txt
@@ -13,9 +13,9 @@
 #==============================================================
 
 SpeedTrig	KEYWORD1
-radToMicro KEYWORD2
-floatToInt KEYWORD2
-sin KEYWORD2
-cos KEYWORD2
-acos KEYWORD2
-atan2 KEYWORD2
+radToMicro	KEYWORD2
+floatToInt	KEYWORD2
+sin	KEYWORD2
+cos	KEYWORD2
+acos	KEYWORD2
+atan2	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords